### PR TITLE
Update to 4.7.0

### DIFF
--- a/ee.ria.qdigidoc4.metainfo.xml
+++ b/ee.ria.qdigidoc4.metainfo.xml
@@ -53,6 +53,13 @@
     <binary>qdigidoc4</binary>
   </provides>
   <releases>
+    <release version="4.7.0" date="2025-01-02">
+      <description>
+        <ul>
+          <li>Code, Text and translation improvements and updates.</li>
+        </ul>
+      </description>
+    </release>
     <release version="4.5.1" date="2024-04-17">
       <description>
         <ul>

--- a/ee.ria.qdigidoc4.yml
+++ b/ee.ria.qdigidoc4.yml
@@ -111,6 +111,7 @@ modules:
       - --disable-serial
       - --disable-usb
       - --disable-documentation
+      - --disable-polkit
     cleanup:
       - /sbin
     sources:

--- a/ee.ria.qdigidoc4.yml
+++ b/ee.ria.qdigidoc4.yml
@@ -4,7 +4,6 @@ runtime: org.kde.Platform
 runtime-version: '6.7'
 sdk: org.kde.Sdk
 rename-icon: qdigidoc4
-rename-desktop-file: qdigidoc4.desktop
 rename-mime-file: qdigidoc4.xml
 rename-mime-icons: ["application-x-cdoc","application-vnd.etsi.asic-e+zip"]
 
@@ -21,6 +20,7 @@ finish-args:
   # Smartcard
   - --socket=pcsc
   - --device=all
+  - --filesystem=home
 
 cleanup:
   - /include
@@ -37,6 +37,7 @@ modules:
       - type: archive
         url: https://github.com/google/flatbuffers/archive/refs/tags/v24.3.25.zip
         sha256: e706f5eb6ca8f78e237bf3f7eccffa1c5ec9a96d3c1c938f08dc09aab1884528
+
   - name: xerces-c
     buildsystem: cmake-ninja
     sources:
@@ -52,28 +53,13 @@ modules:
         sha256: ee7d4b0b08c5676f5e586c7154d94a5b32b299ac3cbb946e24c4375a25552da7
       - type: patch
         path: xalan-c/CMakeLists.patch
-  
-  - name: xsd
-    buildsystem: simple
-    build-commands:
-      - make CXXFLAGS=-std=c++11 -j
-      - make install install_prefix=/app
-    sources:
-      - type: archive
-        url: https://www.codesynthesis.com/download/xsd/4.0/xsd-4.0.0+dep.tar.bz2
-        sha256: eca52a9c8f52cdbe2ae4e364e4a909503493a0d51ea388fc6c9734565a859817
-      - type: patch
-        path: xsd/missing-include.patch
 
-  - name: xml-security-c
+  - name: xmlsec1-openssl
     buildsystem: autotools
-    config-opts:
-      # TODO: we actually do have xalan in the build tree, so we could use it?
-      - --with-xalan=no
     sources:
       - type: archive
-        url: https://downloads.apache.org/santuario/c-library/xml-security-c-2.0.4.tar.gz
-        sha256: a78da6720f6c2ba14100d2426131e0d33eac5a2dba5cc11bdd04974b7eb89003
+        url: https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz
+        sha256: d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea
 
   - name: xxd
     buildsystem: simple
@@ -90,8 +76,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://github.com/open-eid/libdigidocpp/releases/download/v3.17.0/libdigidocpp-3.17.0.tar.gz
-        sha256: 72513d8b6371556deb4faa2ecbb86d35746e71ee30cf12020a31fafcbffcc272
+        url: https://github.com/open-eid/libdigidocpp/releases/download/v4.1.0/libdigidocpp-4.1.0.tar.gz
+        sha256: 958ed454085d59a74b50a476d5ecd47d67355ddbff31685f23f6f2e1bb5cbebf
 
   - name: openldap
     buildsystem: autotools
@@ -144,8 +130,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://github.com/open-eid/DigiDoc4-Client/releases/download/v4.5.1/qdigidoc4_4.5.1.4455-2004.tar.xz
-        sha256: 2d61b10c121aaf45c6a6c1b00862645c39d7dab5e6a15b115239541df9b42600
+        url: https://github.com/open-eid/DigiDoc4-Client/releases/download/v4.7.0/qdigidoc4_4.7.0.4460-2004.tar.xz
+        sha256: 570bd010dedbbea2833d46bb90986a367f4650253949e708372fe50e4b72e824
       - type: patch
         path: qdigidoc4/QPKCS11.patch
       - type: patch
@@ -156,12 +142,12 @@ modules:
       # https://github.com/open-eid/DigiDoc4-Client/wiki/DeveloperTips#building-in-sandboxed-environment
       - type: file
         url: https://ec.europa.eu/tools/lotl/eu-lotl.xml
-        sha256: 83bfb2f565a5f84ca8a40ab4fb61077c29d27283b2f59766201602b98a3466c4
+        sha256: 804b3408c7c96fd0bbca8041b343d501f935d1eb1aa09818eec9adac000000ab
         dest: client
         dest-filename: eu-lotl.xml
       - type: file
         url: https://sr.riik.ee/tsl/estonian-tsl.xml
-        sha256: 472d248b30c849873173c6dee0a3de417996110c2704cf5a261bca99d3c0d1d4
+        sha256: 245e6261d1d0bb10a65dc4d65d599a54dd611596a0d36bdf8203c85c82a3426a
         dest: client
         dest-filename: EE.xml
       - type: file
@@ -170,12 +156,12 @@ modules:
         dest-filename: TSL.qrc
       - type: file
         url: https://id.eesti.ee/config.json
-        sha256: 2ce5693a53db2280239dab0aed36cd1a6befc5bf81639319c481c11f172bd159
+        sha256: ff912ef0cb2cb772d7a0337e14f1d29833f0efe4b2ff72b697b1347c497d4376
         dest: common
         dest-filename: config.json
       - type: file
         url: https://id.eesti.ee/config.rsa
-        sha256: f036793c18e7b97f49727e25a68b3c730b35d83d3c6bee534fde90650397ce66
+        sha256: 5b4bb78f505e9662015fb90a1245f4bcbd791504f69f4d0c731bc30f3583df10
         dest: common
         dest-filename: config.rsa
       - type: file
@@ -196,4 +182,4 @@ modules:
       - install -Dm644 ee.ria.qdigidoc4.metainfo.xml $FLATPAK_DEST/share/metainfo/ee.ria.qdigidoc4.metainfo.xml
       - ln -s $FLATPAK_DEST/share/locale/et/LC_MESSAGES/nautilus-qdigidoc.mo $FLATPAK_DEST/share/locale/et/nautilus-qdigidoc.mo
       - ln -s $FLATPAK_DEST/share/locale/ru/LC_MESSAGES/nautilus-qdigidoc.mo $FLATPAK_DEST/share/locale/ru/nautilus-qdigidoc.mo
-      - desktop-file-edit --set-key=Exec --set-value="run.sh" /app/share/applications/qdigidoc4.desktop
+      - desktop-file-edit --set-key=Exec --set-value="run.sh" /app/share/applications/ee.ria.qdigidoc4.desktop

--- a/ee.ria.qdigidoc4.yml
+++ b/ee.ria.qdigidoc4.yml
@@ -115,8 +115,8 @@ modules:
       - /sbin
     sources:
       - type: archive
-        url: https://github.com/LudovicRousseau/PCSC/archive/refs/tags/2.0.0.tar.gz
-        sha256: 04f5b9d966b2ada91f699f0b968dd716b381b08ae3cf804832c310f65d329066
+        url: https://github.com/LudovicRousseau/PCSC/archive/refs/tags/2.3.1.tar.gz
+        sha256: 7fcb59f66a323f63cf1ab492579a57d899806835c52ba377af9ac57df68bf39b
 
   - name: opensc
     cleanup:

--- a/ee.ria.qdigidoc4.yml
+++ b/ee.ria.qdigidoc4.yml
@@ -143,7 +143,7 @@ modules:
       # https://github.com/open-eid/DigiDoc4-Client/wiki/DeveloperTips#building-in-sandboxed-environment
       - type: file
         url: https://ec.europa.eu/tools/lotl/eu-lotl.xml
-        sha256: 804b3408c7c96fd0bbca8041b343d501f935d1eb1aa09818eec9adac000000ab
+        sha256: ea190b7b13e652b577deeb7c19201ffc55ee9c5002e9c94c2f127030f4cc441f
         dest: client
         dest-filename: eu-lotl.xml
       - type: file
@@ -157,12 +157,12 @@ modules:
         dest-filename: TSL.qrc
       - type: file
         url: https://id.eesti.ee/config.json
-        sha256: ff912ef0cb2cb772d7a0337e14f1d29833f0efe4b2ff72b697b1347c497d4376
+        sha256: 0eb3239781628de3b725a88bb1264496368d320f368a7f76f5e2128325981544
         dest: common
         dest-filename: config.json
       - type: file
         url: https://id.eesti.ee/config.rsa
-        sha256: 5b4bb78f505e9662015fb90a1245f4bcbd791504f69f4d0c731bc30f3583df10
+        sha256: 8a8d15bac8c0d6efaf98c9623cbd56f0a5733d41965e8aafa9dfea61e3f12788
         dest: common
         dest-filename: config.rsa
       - type: file

--- a/qdigidoc4/client-CMakeLists.patch
+++ b/qdigidoc4/client-CMakeLists.patch
@@ -1,27 +1,22 @@
 diff --git a/client/CMakeLists.txt b/client/CMakeLists.txt
-index 6a48248..31f6136 100644
+index b2251bc..910b7db 100644
 --- a/client/CMakeLists.txt
 +++ b/client/CMakeLists.txt
-@@ -1,13 +1,5 @@
--add_executable( TSLDownload TSLDownload.cpp )
--target_link_libraries(TSLDownload Qt${QT_VERSION_MAJOR}::Network)
- get_target_property(qtCore_install_prefix Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
- get_filename_component(qtCore_install_prefix ${qtCore_install_prefix} DIRECTORY)
--add_custom_command(
--	OUTPUT TSL.qrc
--	DEPENDS TSLDownload
--	COMMAND $<TARGET_FILE:TSLDownload> "${CMAKE_CURRENT_BINARY_DIR}" ${TSL_URL} ${TSL_INCLUDE}
--	WORKING_DIRECTORY ${qtCore_install_prefix}
--)
+@@ -1,17 +1,9 @@
+ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/TSL.qrc)
+ 	set(TSL_QRC ${CMAKE_CURRENT_SOURCE_DIR}/TSL.qrc)
+ else()
+-	add_executable(TSLDownload TSLDownload.cpp)
+-	target_link_libraries(TSLDownload Qt${QT_VERSION_MAJOR}::Network)
+ 	set_target_properties(TSLDownload PROPERTIES AUTOMOC OFF)
+ 	get_target_property(qtCore_install_prefix Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+ 	get_filename_component(qtCore_install_prefix ${qtCore_install_prefix} DIRECTORY)
+-	add_custom_command(
+-		OUTPUT TSL.qrc
+-		DEPENDS TSLDownload
+-		COMMAND $<TARGET_FILE:TSLDownload> "${CMAKE_CURRENT_BINARY_DIR}" ${TSL_URL} ${TSL_INCLUDE}
+-		WORKING_DIRECTORY ${qtCore_install_prefix}
+-	)
+ 	set(TSL_QRC ${CMAKE_CURRENT_BINARY_DIR}/TSL.qrc)
+ endif()
  
- configure_file( translations/tr.qrc tr.qrc COPYONLY )
- qt_add_translation(SOURCES translations/en.ts translations/et.ts translations/ru.ts)
-@@ -20,7 +12,7 @@
- 	images/images.qrc
- 	fonts/fonts.qrc
- 	${CMAKE_CURRENT_BINARY_DIR}/tr.qrc
--	${CMAKE_CURRENT_BINARY_DIR}/TSL.qrc
-+	TSL.qrc
- 	main.cpp
- 	Application.cpp
- 	CheckConnection.cpp

--- a/qdigidoc4/common-CMakeLists.patch
+++ b/qdigidoc4/common-CMakeLists.patch
@@ -1,19 +1,25 @@
 diff --git a/common/CMakeLists.txt b/common/CMakeLists.txt
-index b091756..952d2c3 100644
+index 451291b..e394051 100644
 --- a/common/CMakeLists.txt
 +++ b/common/CMakeLists.txt
-@@ -40,13 +40,7 @@
+@@ -54,19 +54,7 @@ if( CONFIG_URL )
  	if( LAST_CHECK_DAYS )
- 		set_source_files_properties( Configuration.cpp PROPERTIES COMPILE_DEFINITIONS "LAST_CHECK_DAYS=${LAST_CHECK_DAYS}" )
+ 		set_source_files_properties(Configuration.cpp PROPERTIES COMPILE_DEFINITIONS LAST_CHECK_DAYS=${LAST_CHECK_DAYS})
  	endif()
--	file( DOWNLOAD ${CONFIG_URL} ${CMAKE_CURRENT_BINARY_DIR}/config.json )
--	string( REPLACE ".json" ".rsa" RSA_URL ${CONFIG_URL} )
--	file( DOWNLOAD ${RSA_URL} ${CMAKE_CURRENT_BINARY_DIR}/config.rsa )
--	string( REPLACE ".json" ".pub" PUB_URL ${CONFIG_URL} )
--	file( DOWNLOAD ${PUB_URL} ${CMAKE_CURRENT_BINARY_DIR}/config.pub )
--	configure_file( config.qrc config.qrc COPYONLY )
--	qt_add_resources(CONFIG_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/config.qrc)
+-	if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.json AND
+-		EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.rsa AND
+-		EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.pub)
+-		qt_add_resources(CONFIG_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config.qrc)
+-	else()
+-		file(DOWNLOAD ${CONFIG_URL} ${CMAKE_CURRENT_BINARY_DIR}/config.json)
+-		string(REPLACE ".json" ".rsa" RSA_URL ${CONFIG_URL} )
+-		file(DOWNLOAD ${RSA_URL} ${CMAKE_CURRENT_BINARY_DIR}/config.rsa)
+-		string(REPLACE ".json" ".pub" PUB_URL ${CONFIG_URL} )
+-		file(DOWNLOAD ${PUB_URL} ${CMAKE_CURRENT_BINARY_DIR}/config.pub)
+-		configure_file(config.qrc config.qrc COPYONLY)
+-		qt_add_resources(CONFIG_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/config.qrc)
+-	endif()
 +	qt_add_resources(CONFIG_SOURCES config.qrc)
  	target_compile_definitions(qdigidoccommon PUBLIC CONFIG_URL="${CONFIG_URL}")
- 	target_sources(qdigidoccommon PRIVATE ${CONFIG_SOURCES} Configuration.cpp )
+ 	target_sources(qdigidoccommon PRIVATE ${CONFIG_SOURCES} Configuration.cpp)
  endif()


### PR DESCRIPTION
Tere!

I'm not a C++ developer and I've never made any Flatpaks before, but these changes seem to make 4.7.0 possible, and also fixes double-click and drag-and-drop to open .asice files (in /home, could be restricted to Desktop, Documents and Downloads perhaps).

I've tested:
- Creating and signing .asice with Smart ID.
- Opening .asice using double click
- Opening .asice using "load file from disk" button
- Opening .asice using drag-and-drop from Gnome Files.

Please review carefully, especially this addition which might be way off (but seems to be working):

```
- name: xmlsec1-openssl
    buildsystem: autotools
    sources:
      - type: archive
        url: https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz
        sha256: d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea
```